### PR TITLE
MinIO URL Resolver for AI Container

### DIFF
--- a/apps/ai/app/main.py
+++ b/apps/ai/app/main.py
@@ -20,6 +20,7 @@ from app.services.whisper_service import (
     UnsupportedMediaError,
 )
 from app.services import whisper_service
+from app.utils.url_resolver import resolve_minio_url
 
 
 app = FastAPI(
@@ -54,7 +55,7 @@ class ImageModerationResponse(BaseModel):
     "/moderation/image",
     response_model=ImageModerationResponse,
     summary="Moderate image with Google Gemini",
-    description="Supports file upload or presigned URL. JPEG/PNG/WebP/GIF.",
+    description="Supports file upload or presigned URL. JPEG/PNG/WebP/HEIC/HEIF ONLY.",
 )
 async def moderate_image(
     file: Optional[UploadFile] = File(None),
@@ -73,6 +74,7 @@ async def moderate_image(
         logging.getLogger(__name__).info("Both file and file_url provided; using uploaded file.")
 
     # 1) load image bytes
+    if file is not None:
         if file.content_type not in ("image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"):
             raise HTTPException(
                 status_code=400,
@@ -81,10 +83,18 @@ async def moderate_image(
         mime_type = file.content_type
         image_bytes = await file.read()
     else:
+        if file_url is None:
+            raise HTTPException(
+                status_code=400,
+                detail="file_url is required when file is not provided.",
+            )
+        resolved_url = resolve_minio_url(file_url)
+        logging.getLogger(__name__).info(f"Resolved URL: {file_url} -> {resolved_url}")
+
         # download from presigned URL
         async with httpx.AsyncClient(timeout=15) as client_http:
             try:
-                resp = await client_http.get(file_url)
+                resp = await client_http.get(resolved_url)
                 resp.raise_for_status()
             except httpx.HTTPError as e:
                 raise HTTPException(
@@ -107,6 +117,7 @@ async def moderate_image(
         raise HTTPException(500, f"Unexpected error during image moderation: {e}")
 
     return ImageModerationResponse(**result)
+
 
 
 class TranscribeAndSummarizeRequest(TranscribeRequest):
@@ -200,10 +211,13 @@ async def detect_emotion(
             )
         image_bytes = await file.read()
     else:
+        resolved_url = resolve_minio_url(file_url)
+        logging.getLogger(__name__).info(f"Emotion detect - Resolved URL: {file_url} -> {resolved_url}")
+
         # download from presigned URL
         async with httpx.AsyncClient(timeout=20) as client:
             try:
-                resp = await client.get(file_url)
+                resp = await client.get(resolved_url)
                 resp.raise_for_status()
             except Exception as e:
                 raise HTTPException(

--- a/apps/ai/app/main.py
+++ b/apps/ai/app/main.py
@@ -73,11 +73,10 @@ async def moderate_image(
         logging.getLogger(__name__).info("Both file and file_url provided; using uploaded file.")
 
     # 1) load image bytes
-    if file is not None:
-        if file.content_type not in ("image/jpeg", "image/png", "image/webp", "image/gif"):
+        if file.content_type not in ("image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"):
             raise HTTPException(
                 status_code=400,
-                detail="Only JPEG, PNG, WebP, and GIF are allowed.",
+                detail="Only JPEG, PNG, WebP, HEIC, HEIF are supported.",
             )
         mime_type = file.content_type
         image_bytes = await file.read()

--- a/apps/ai/app/services/gemini_moderation.py
+++ b/apps/ai/app/services/gemini_moderation.py
@@ -155,13 +155,13 @@ def moderate_image(
 ) -> Dict[str, Any]:
     """
     Production-ready image moderation function.
-    - Size validation & compression
-    - Gemini API call with retry
-    - Apply threshold
-    - Returns is_safe, reason, categories
+    Supports: JPEG, PNG, WebP, HEIC, HEIF (NOT GIF - Gemini limitation)
     """
-    if mime_type not in ("image/jpeg", "image/png", "image/webp", "image/gif"):
-        raise ModerationError(f"Unsupported image type: {mime_type}")
+    if mime_type not in ("image/jpeg", "image/png", "image/webp", "image/heic", "image/heif"):
+        raise ModerationError(
+            f"Unsupported image type: {mime_type}. "
+            "Gemini supports: JPEG, PNG, WebP, HEIC, HEIF only."
+        )
 
     original_size = len(image_bytes)
     image_bytes, compressed = _compress_if_needed(image_bytes)

--- a/apps/ai/app/utils/__init__.py
+++ b/apps/ai/app/utils/__init__.py
@@ -1,0 +1,5 @@
+# apps/ai/app/utils/__init__.py
+
+from .url_resolver import resolve_minio_url, is_local_minio_url
+
+__all__ = ['resolve_minio_url', 'is_local_minio_url']

--- a/apps/ai/app/utils/url_resolver.py
+++ b/apps/ai/app/utils/url_resolver.py
@@ -1,0 +1,48 @@
+# apps/ai/app/utils/url_resolver.py
+
+import re
+from urllib.parse import urlparse, urlunparse
+from app.core.config import settings
+
+
+def resolve_minio_url(url: str) -> str:
+    """
+    Convert external MinIO URLs to internal Docker network URLs.
+
+    Examples:
+        http://localhost:9000/bucket/file.jpg -> http://minio:9000/bucket/file.jpg
+        http://100.92.51.75:9000/bucket/file.jpg -> http://minio:9000/bucket/file.jpg
+        http://minio:9000/bucket/file.jpg -> http://minio:9000/bucket/file.jpg (unchanged)
+
+    Args:
+        url: Original URL from media.py or posts.py
+
+    Returns:
+        Resolved URL using Docker network hostname
+    """
+    if not url:
+        return url
+
+    parsed = urlparse(url)
+
+    # Check if it's a MinIO URL (port 9000 is the indicator)
+    if parsed.port == 9000:
+        # Replace hostname with 'minio' for Docker network
+        resolved = urlunparse((
+            parsed.scheme,           # http
+            f'minio:{parsed.port}',  # minio:9000
+            parsed.path,             # /bucket/file.jpg
+            parsed.params,
+            parsed.query,            # presigned params
+            parsed.fragment
+        ))
+        return resolved
+
+    # Not a MinIO URL, return as-is
+    return url
+
+
+def is_local_minio_url(url: str) -> bool:
+    """Check if URL points to our MinIO instance"""
+    parsed = urlparse(url)
+    return parsed.port == 9000 and parsed.hostname in ('localhost', 'minio', '100.92.51.75')


### PR DESCRIPTION
This pull request introduces support for HEIC and HEIF image formats in moderation endpoints and refactors media URL handling to reliably resolve MinIO URLs, ensuring compatibility in Docker environments. It also improves error handling and type definitions in the Whisper transcription service, and adds a new utility for URL resolution.

**Image Moderation and Emotion Detection Improvements**
* Added support for HEIC and HEIF image formats and clarified supported formats in API descriptions and error messages; removed GIF support due to Gemini API limitations. [[1]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8L57-R58) [[2]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8L77-R97) [[3]](diffhunk://#diff-1958f18baec4b962650e5369d8a07b810e0889c31ad193665c844826421cfc14L158-R164)

**MinIO URL Resolution Refactor**
* Introduced `resolve_minio_url` utility to convert external MinIO URLs to internal Docker network URLs, and applied it to image moderation, emotion detection, and Whisper transcription endpoints for robust media access. [[1]](diffhunk://#diff-848f3955c8e5671a66478d4c007b3eef5fa3932e0608664ebc7f0ff359a19b20R1-R48) [[2]](diffhunk://#diff-8938f92c49fc7247ef434a37d36cb99e27d1bc478170b8ec81fde37e06741d11R1-R5) [[3]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8R23) [[4]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8L77-R97) [[5]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8R214-R220) [[6]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cR11-R18) [[7]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cR140-R149) [[8]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cL163-R195)

**Whisper Service Enhancements**
* Improved type definitions for Whisper transcription results and segments, added detailed duration parsing logic to handle various formats, and ensured temporary files are cleaned up after processing. [[1]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cR38-R42) [[2]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cL186-R222) [[3]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cL199-L201)

**General Codebase Organization**
* Added new utility files: `apps/ai/app/utils/url_resolver.py` for URL resolution logic and updated `apps/ai/app/utils/__init__.py` to expose relevant functions. [[1]](diffhunk://#diff-848f3955c8e5671a66478d4c007b3eef5fa3932e0608664ebc7f0ff359a19b20R1-R48) [[2]](diffhunk://#diff-8938f92c49fc7247ef434a37d36cb99e27d1bc478170b8ec81fde37e06741d11R1-R5)

**Error Handling Improvements**
* Improved error messages for unsupported media types and missing file URLs, providing clearer feedback to API consumers. [[1]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8L77-R97) [[2]](diffhunk://#diff-1958f18baec4b962650e5369d8a07b810e0889c31ad193665c844826421cfc14L158-R164)

Encoded references: [[1]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8L57-R58) [[2]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8L77-R97) [[3]](diffhunk://#diff-1958f18baec4b962650e5369d8a07b810e0889c31ad193665c844826421cfc14L158-R164) [[4]](diffhunk://#diff-848f3955c8e5671a66478d4c007b3eef5fa3932e0608664ebc7f0ff359a19b20R1-R48) [[5]](diffhunk://#diff-8938f92c49fc7247ef434a37d36cb99e27d1bc478170b8ec81fde37e06741d11R1-R5) [[6]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8R23) [[7]](diffhunk://#diff-0c5c23f5dda902747cdaab00b9a8d624ed421b3d793363573eeebdfabec751b8R214-R220) [[8]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cR11-R18) [[9]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cR140-R149) [[10]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cL163-R195) [[11]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cR38-R42) [[12]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cL186-R222) [[13]](diffhunk://#diff-09e1171fb36fa6f57ddba92c1a9ba563d967da1f166b5dfa681839ab5a2ae76cL199-L201)