### PR TITLE
Fix Captions & Video

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -25,7 +25,9 @@ app = FastAPI(
 default_origins = [
     "https://project.geeb.pp.ua",
     "http://localhost:3000",
+    "http://localhost:3001",
     "http://127.0.0.1:3000",
+    "http://127.0.0.1:3001",
     "http://localhost:8000",
     "https://project.geeb.pp.ua",
 ]

--- a/apps/web/app/feed/page.tsx
+++ b/apps/web/app/feed/page.tsx
@@ -22,6 +22,7 @@ function mapToPostCardPost(post: Post): PostCardPost {
       public_url: post.media.public_url,
       media_type: post.media.media_type as 'image' | 'video',
       caption: post.media.caption,
+      transcription_url: post.media.transcription_url ?? null,
     } : null,
     created_at: post.created_at,
     likes_count: post.likes_count,

--- a/apps/web/components/ui/posts/CreatePostModal.tsx
+++ b/apps/web/components/ui/posts/CreatePostModal.tsx
@@ -152,11 +152,11 @@ export default function CreatePostModal({
         setUploadedMediaUrl(data?.data?.public_url || null);
         mediaType = file.type.startsWith("video/") ? "video" : "image";
 
-        // Moderate uploaded media via backend proxy
+        // Moderate uploaded media via backend proxy (images and videos)
         try {
           const modRes = await api.post(
             "/api/v1/media/moderate",
-            { file_url: data?.data?.public_url, user: undefined },
+            { file_url: data?.data?.public_url, media_type: mediaType, user: undefined },
             {
               headers: { Authorization: `Bearer ${accessToken}` },
               withCredentials: true,

--- a/apps/web/types/index.ts
+++ b/apps/web/types/index.ts
@@ -40,6 +40,7 @@ export interface PostMedia {
   public_url: string;
   media_type: 'image' | 'video' | null;
   caption: string | null;
+  transcription_url?: string | null;
 }
 
 // Post types


### PR DESCRIPTION
This pull request introduces support for video moderation in both the backend and frontend, along with improvements to media handling and error reporting. The main changes enable the system to distinguish between image and video uploads, route them to the appropriate moderation pipelines, and handle their responses accordingly. Additionally, the frontend now passes media type information and supports video transcription URLs.

**Backend enhancements for media moderation:**

* Added `media_type` field to the `MediaModerationRequest` model to distinguish between images and videos.
* Updated the `moderate_media` endpoint to detect media type, route videos to a new `/process-video` AI endpoint, and handle video-specific response fields and errors. [[1]](diffhunk://#diff-86aa420443133a661d1dc16a2ad542505d4c4be75f212f68878bb0ab40758da8R348-R396) [[2]](diffhunk://#diff-86aa420443133a661d1dc16a2ad542505d4c4be75f212f68878bb0ab40758da8R410-R423)

**Frontend support for video moderation and transcription:**

* Updated the `CreatePostModal` to send the `media_type` when requesting moderation, ensuring both images and videos are processed correctly.
* Improved post-moderation cleanup logic to delete media if moderation fails, including for videos.
* Extended `PostMedia` and related mapping to support an optional `transcription_url` for video posts. [[1]](diffhunk://#diff-3a0ac7b55f67e60e0b563abcb67838ce3ca6e78a6085b3de42bb75a15f8b8243R43) [[2]](diffhunk://#diff-dcfb384ee9c1cd817f299d84ae6a45c6a8e2489ce3ea62232d68192bdf0b046dR25)

**Configuration update:**

* Added `localhost:3001` and `127.0.0.1:3001` to the allowed CORS origins for local development.